### PR TITLE
Fix 'invalid urlencoded received' when submitting form from url with …

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ request.urlencoded = function (limit) {
 }
 
 request._parse_urlencoded = function (text) {
-  const parse = (this.app.querystring || qs).parse
+  const parse = qs.parse
   try {
     return parse(text)
   } catch (err) {


### PR DESCRIPTION
…query

I'm using koa-better-body and for whatever reason, this module is used.
If I try to submit a login form, and that form is on a url that ends with a query string e.g. '/login?nextURL=/'
this.app.querystring shows up as a string '?nextURL=/'. 

That OR block makes no logical sense as this.app.querystring is always a string, and strings have no parse function.
Why not just use qs directly and combine both url and body query objects?