### PR TITLE
Feature(Service): verify is querystring own parse function

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,10 @@ request.urlencoded = function (limit) {
 }
 
 request._parse_urlencoded = function (text) {
-  const parse = (this.app.querystring || qs).parse
+  const parse = (
+    this.app.querystring
+    && this.app.querystring.parse
+  ) || qs.parse;
   try {
     return parse(text)
   } catch (err) {


### PR DESCRIPTION
I meet the case of `this.app.querystring.parse` was not a `function` but `this.app.querystring` exists.
So obviously, it thrown an error.